### PR TITLE
fix frequency setter and misc items

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,8 +49,9 @@ The baud rate may be specified as an keyword parameter when initializing the boa
 To set it to 1000000 use :
 
 .. code-block:: python
-# Initialze RFM radio
-rfm9x = adafruit_rfm9x.RFM9x(spi, CS, RESET, RADIO_FREQ_MHZ,baudrate=1000000)
+
+    # Initialze RFM radio
+    rfm9x = adafruit_rfm9x.RFM9x(spi, CS, RESET, RADIO_FREQ_MHZ,baudrate=1000000)
 
 
 Contributing

--- a/README.rst
+++ b/README.rst
@@ -39,8 +39,19 @@ This is easily achieved by downloading
 
 Usage Example
 =============
-
 See examples/rfm69_simpletest.py for a simple demo of the usage.
+Note: the default baudrate for the SPI is 50000000 (5MHz). 
+The maximum setting is 10Mhz but 
+transmission errors have been observed expecially when using breakout boards.
+For breakout boards or other configurations where the boards are separated,
+it may be necessary to reduce the baudrate for reliable data transmission.
+The baud rate may be specified as an keyword parameter when initializing the board.
+To set it to 1000000 use :
+.. code-block:: python# Initialze RFM radio
+.. code-block:: python
+    # Initialze RFM radio
+     rfm9x = adafruit_rfm9x.RFM9x(spi, CS, RESET, RADIO_FREQ_MHZ,baudrate=1000000)
+
 
 Contributing
 ============

--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ To set it to 1000000 use :
 .. code-block:: python# Initialze RFM radio
 .. code-block:: python
     # Initialze RFM radio
-     rfm9x = adafruit_rfm9x.RFM9x(spi, CS, RESET, RADIO_FREQ_MHZ,baudrate=1000000)
+    rfm9x = adafruit_rfm9x.RFM9x(spi, CS, RESET, RADIO_FREQ_MHZ,baudrate=1000000)
 
 
 Contributing

--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,7 @@ For breakout boards or other configurations where the boards are separated,
 it may be necessary to reduce the baudrate for reliable data transmission.
 The baud rate may be specified as an keyword parameter when initializing the board.
 To set it to 1000000 use :
+
 .. code-block:: python
 # Initialze RFM radio
 rfm9x = adafruit_rfm9x.RFM9x(spi, CS, RESET, RADIO_FREQ_MHZ,baudrate=1000000)

--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,6 @@ For breakout boards or other configurations where the boards are separated,
 it may be necessary to reduce the baudrate for reliable data transmission.
 The baud rate may be specified as an keyword parameter when initializing the board.
 To set it to 1000000 use :
-.. code-block:: python# Initialze RFM radio
 .. code-block:: python
 # Initialze RFM radio
 rfm9x = adafruit_rfm9x.RFM9x(spi, CS, RESET, RADIO_FREQ_MHZ,baudrate=1000000)

--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ This is easily achieved by downloading
 Usage Example
 =============
 See examples/rfm69_simpletest.py for a simple demo of the usage.
-Note: the default baudrate for the SPI is 50000000 (5MHz). 
+Note: the default baudrate for the SPI is 5000000 (5MHz). 
 The maximum setting is 10Mhz but 
 transmission errors have been observed expecially when using breakout boards.
 For breakout boards or other configurations where the boards are separated,

--- a/README.rst
+++ b/README.rst
@@ -49,8 +49,8 @@ The baud rate may be specified as an keyword parameter when initializing the boa
 To set it to 1000000 use :
 .. code-block:: python# Initialze RFM radio
 .. code-block:: python
-    # Initialze RFM radio
-    rfm9x = adafruit_rfm9x.RFM9x(spi, CS, RESET, RADIO_FREQ_MHZ,baudrate=1000000)
+# Initialze RFM radio
+rfm9x = adafruit_rfm9x.RFM9x(spi, CS, RESET, RADIO_FREQ_MHZ,baudrate=1000000)
 
 
 Contributing

--- a/adafruit_rfm69.py
+++ b/adafruit_rfm69.py
@@ -340,7 +340,7 @@ class RFM69:
         # Set the preamble length.
         self.preamble_length = preamble_length
         # Set frequency.
-        self.frequency = frequency
+        self.frequency_mhz = frequency
         # Set encryption key.
         self.encryption_key = encryption_key
         # Set transmit power to 13 dBm, a safe value any module supports.

--- a/adafruit_rfm69.py
+++ b/adafruit_rfm69.py
@@ -707,8 +707,6 @@ class RFM69:
         self.transmit()
         # Wait for packet sent interrupt with explicit polling (not ideal but
         # best that can be done right now without interrupts).
-        while not self.packet_sent:
-            pass
         start = time.monotonic()
         timed_out = False
         while not timed_out and not self.packet_sent:

--- a/examples/rfm69_simpletest.py
+++ b/examples/rfm69_simpletest.py
@@ -51,7 +51,7 @@ print('Waiting for packets...')
 while True:
     packet = rfm69.receive()
     # Optionally change the receive timeout from its default of 0.5 seconds:
-    #packet = rfm69.receive(timeout_s=5.0)
+    #packet = rfm69.receive(timeout=5.0)
     # If no packet was received during the timeout then None is returned.
     if packet is None:
         print('Received nothing! Listening again...')


### PR DESCRIPTION
This fixes the frequency setter to correctly set fewquency_mhz.
I also added a timeout to the send function to avoid a potential hang.
the parameters to set the send/receive timeouts were renamed from timeout_s to timeout to be compatible with the standard naming conventions.
The deafault SPI baudrate was lowered to 5MHz as was done for the RF95x to avoid problems with the breakout boards.

Note : I cannot make any sense of the RSSI readings from this module. I did not change the way they are reported and this issue was present in the current release, but the values reported are much lower than expected and much lower than those reported by Arduino.

I tested this with both an RFM69HCW featherwing and an RFM69HCW breakout board