### PR TITLE
 fix rfm69_simpletest for execution on Raspbery Pi

### DIFF
--- a/examples/rfm69_simpletest.py
+++ b/examples/rfm69_simpletest.py
@@ -41,7 +41,7 @@ print('Frequency deviation: {0}hz'.format(rfm69.frequency_deviation))
 # This is a limitation of the radio packet size, so if you need to send larger
 # amounts of data you will need to break it into smaller send calls.  Each send
 # call will wait for the previous one to finish before continuing.
-rfm69.send('Hello world!\r\n')
+rfm69.send(bytes('Hello world!\r\n',"utf-8"))
 print('Sent hello world message!')
 
 # Wait to receive packets.  Note that this library can't receive data at a fast


### PR DESCRIPTION
For compatibility with Python3 on the Raspberry Pi -- the argument to rfm69.send() has to be converted to a bytes object. With this change, the example run in CircuitPython and on the RaspberryPi via Blinka.
It as tested on a Raspberry Pi 3B+ and on a feather_m0_adalogger with an rfm69 featherwing.