### PR TITLE
Allow access to RadioHead packet headers

### DIFF
--- a/adafruit_rfm69.py
+++ b/adafruit_rfm69.py
@@ -679,7 +679,9 @@ class RFM69:
         """Send a string of data using the transmitter.
            You can only send 60 bytes at a time
            (limited by chip's FIFO size and appended headers).
-           Note this appends a 4 byte header to be compatible with the RadioHead library.
+           This appends a 4 byte header to be compatible with the RadioHead library.
+           The tx_header defaults to using the Broadcast addresses. It may be overidden
+           by specifying a 4-tuple of bytes containing (To,From,ID,Flags)
            The timeout is just to prevent a hang (arbitrarily set to 2 seconds)
         """
         # Disable pylint warning to not use length as a check for zero.
@@ -725,10 +727,22 @@ class RFM69:
         """Wait to receive a packet from the receiver. Will wait for up to timeout_s amount of
            seconds for a packet to be received and decoded. If a packet is found the payload bytes
            are returned, otherwise None is returned (which indicates the timeout elapsed with no
-           reception). Note this assumes a 4-byte header is prepended to the data for compatibilty
-           with the RadioHead library (the header is not validated nor returned). If keep_listening
-           is True (the default) the chip will immediately enter listening mode after reception of
-           a packet, otherwise it will fall back to idle mode and ignore any future reception.
+           reception).
+           If keep_listening is True (the default) the chip will immediately enter listening mode
+           after reception of a packet, otherwise it will fall back to idle mode and ignore any
+           future reception.
+           A 4-byte header must be prepended to the data for compatibilty with the
+           RadioHead library.
+           The header consists of a 4 bytes (To,From,ID,Flags). The default setting will accept
+           any  incomming packet and strip the header before returning the packet to the caller.
+           If with_header is True then the 4 byte header will be returned with the packet.
+           The payload then begins at packet[4].
+           rx_fliter may be set to reject any "non-broadcast" packets that do not contain the
+           specfied "To" value in the header.
+           if rx_filter is set to 0xff (_RH_BROADCAST_ADDRESS) or if the  "To" field (packet[[0])
+           is equal to 0xff then the packet will be accepted and returned to the caller.
+           If rx_filter is not 0xff and packet[0] does not match rx_filter then
+           the packet is ignored and None is returned.
         """
         # Make sure we are listening for packets.
         self.listen()

--- a/adafruit_rfm69.py
+++ b/adafruit_rfm69.py
@@ -748,6 +748,9 @@ class RFM69:
         if timed_out:
             return None
         # Read the data from the FIFO.
+        # pylint: disable=len-as-condition
+        assert len(rx_filter) == 2, "rx filter must be 2-tuple (To,From)"
+        # pylint: enable=len-as-condition
         with self._device as device:
             self._BUFFER[0] = _REG_FIFO & 0x7F  # Strip out top bit to set 0
                                                 # value (read).
@@ -770,10 +773,8 @@ class RFM69:
                 else: # ignore packet if rx_filter set and not addressed properly
                     if rx_filter[0] != _RH_BROADCAST_ADDRESS and packet[0] != rx_filter[0]:
                         packet = None
-                        print("packet filtered : To mismatch")
                     elif rx_filter[1] != _RH_BROADCAST_ADDRESS and packet[1] != rx_filter[1]:
                         packet = None
-                        print("packet filtered : From mismatch")
 
         # Listen again if necessary and return the result packet.
         if keep_listening:

--- a/adafruit_rfm69.py
+++ b/adafruit_rfm69.py
@@ -721,7 +721,7 @@ class RFM69:
             raise RuntimeError('Timeout during packet send')
 
     def receive(self, timeout=0.5, keep_listening=True, with_header=False,
-                rx_filter=(_RH_BROADCAST_ADDRESS, _RH_BROADCAST_ADDRESS)):
+                rx_filter=_RH_BROADCAST_ADDRESS):
         """Wait to receive a packet from the receiver. Will wait for up to timeout_s amount of
            seconds for a packet to be received and decoded. If a packet is found the payload bytes
            are returned, otherwise None is returned (which indicates the timeout elapsed with no
@@ -748,9 +748,6 @@ class RFM69:
         if timed_out:
             return None
         # Read the data from the FIFO.
-        # pylint: disable=len-as-condition
-        assert len(rx_filter) == 2, "rx filter must be 2-tuple (To,From)"
-        # pylint: enable=len-as-condition
         with self._device as device:
             self._BUFFER[0] = _REG_FIFO & 0x7F  # Strip out top bit to set 0
                                                 # value (read).
@@ -768,13 +765,11 @@ class RFM69:
             else:
                 packet = bytearray(fifo_length)
                 device.readinto(packet)
-                if not with_header:  # skip the header if not wanted
-                    packet = packet[4:]
-                else: # ignore packet if rx_filter set and not addressed properly
-                    if rx_filter[0] != _RH_BROADCAST_ADDRESS and packet[0] != rx_filter[0]:
-                        packet = None
-                    elif rx_filter[1] != _RH_BROADCAST_ADDRESS and packet[1] != rx_filter[1]:
-                        packet = None
+            if (rx_filter != _RH_BROADCAST_ADDRESS and packet[0] != _RH_BROADCAST_ADDRESS
+                    and packet[0] != rx_filter):
+                packet = None
+            if not with_header:  # skip the header if not wanted
+                packet = packet[4:]
 
         # Listen again if necessary and return the result packet.
         if keep_listening:

--- a/adafruit_rfm69.py
+++ b/adafruit_rfm69.py
@@ -674,7 +674,8 @@ class RFM69:
         self._write_u8(_REG_FDEV_MSB, fdev >> 8)
         self._write_u8(_REG_FDEV_LSB, fdev & 0xFF)
 
-    def send(self, data, timeout=2.):
+    def send(self, data, timeout=2.,
+             tx_header=(_RH_BROADCAST_ADDRESS, _RH_BROADCAST_ADDRESS, 0, 0)):
         """Send a string of data using the transmitter.
            You can only send 60 bytes at a time
            (limited by chip's FIFO size and appended headers).
@@ -687,6 +688,7 @@ class RFM69:
         # buffer be within an expected range of bounds.  Disable this check.
         # pylint: disable=len-as-condition
         assert 0 < len(data) <= 60
+        assert len(tx_header) == 4, "tx header must be 4-tuple (To,From,ID,Flags)"
         # pylint: enable=len-as-condition
         self.idle()  # Stop receiving to clear FIFO and keep it clear.
         # Fill the FIFO with a packet to send.
@@ -697,10 +699,10 @@ class RFM69:
             # Add 4 bytes of headers to match RadioHead library.
             # Just use the defaults for global broadcast to all receivers
             # for now.
-            self._BUFFER[2] = _RH_BROADCAST_ADDRESS # txHeaderTo
-            self._BUFFER[3] = _RH_BROADCAST_ADDRESS # txHeaderFrom
-            self._BUFFER[4] = 0 # txHeaderId
-            self._BUFFER[5] = 0 # txHeaderFlags
+            self._BUFFER[2] = tx_header[0] # Header: To
+            self._BUFFER[3] = tx_header[1] # Header: From
+            self._BUFFER[4] = tx_header[2] # Header: Id
+            self._BUFFER[5] = tx_header[3] # Header: Flags
             device.write(self._BUFFER, end=6)
             # Now send the payload.
             device.write(data)
@@ -718,7 +720,8 @@ class RFM69:
         if timed_out:
             raise RuntimeError('Timeout during packet send')
 
-    def receive(self, timeout=0.5, keep_listening=True):
+    def receive(self, timeout=0.5, keep_listening=True, with_header=False,
+                rx_filter=(_RH_BROADCAST_ADDRESS, _RH_BROADCAST_ADDRESS)):
         """Wait to receive a packet from the receiver. Will wait for up to timeout_s amount of
            seconds for a packet to be received and decoded. If a packet is found the payload bytes
            are returned, otherwise None is returned (which indicates the timeout elapsed with no
@@ -760,13 +763,18 @@ class RFM69:
                 device.readinto(self._BUFFER, end=fifo_length)
                 packet = None
             else:
-                # Read the 4 bytes of the RadioHead header.
-                device.readinto(self._BUFFER, end=4)
-                # Ignore validating any of the header bytes.
-                # Now read the remaining packet payload as the result.
-                fifo_length -= 4
                 packet = bytearray(fifo_length)
                 device.readinto(packet)
+                if not with_header:  # skip the header if not wanted
+                    packet = packet[4:]
+                else: # ignore packet if rx_filter set and not addressed properly
+                    if rx_filter[0] != _RH_BROADCAST_ADDRESS and packet[0] != rx_filter[0]:
+                        packet = None
+                        print("packet filtered : To mismatch")
+                    elif rx_filter[1] != _RH_BROADCAST_ADDRESS and packet[1] != rx_filter[1]:
+                        packet = None
+                        print("packet filtered : From mismatch")
+
         # Listen again if necessary and return the result packet.
         if keep_listening:
             self.listen()


### PR DESCRIPTION
The user may optionally set and receive the 4 byte RadioHead packet header.
I think this mimics the behavior of the Arduino implementation.
The default is to ignore the header as in the past.

On transmit, the user may provide a keyword argument: tx_header with a 4-tuple of bytes.
tx_header = (To,From,ID,Flags)
to set the outgoing header.

On receive, the user can request that the packet header be included at the beginning of the packet via a keyword argument: with_header. 
If set to True, the header will be included as the first 4 bytes of the packet and the data payload begins at byte 4.
Also, the user may specify a keyword argument: rx_filter to reject any "non-broadcast" packets not addressed as specified.  A "broadcast" message contains 0xff as the To address. Broadcast messages are always received. 
If rx_filter is set to a value other than 0xff, then incoming packets with the To field not matching the rx_filter will be ignored unless the To field contains 0xff.
If rx_filter is set to 0xff then all packets are accepted.