### PR TITLE
 fix error when no header requested

### DIFF
--- a/adafruit_rfm69.py
+++ b/adafruit_rfm69.py
@@ -782,7 +782,7 @@ class RFM69:
             if (rx_filter != _RH_BROADCAST_ADDRESS and packet[0] != _RH_BROADCAST_ADDRESS
                     and packet[0] != rx_filter):
                 packet = None
-            if not with_header:  # skip the header if not wanted
+            elif not with_header:  # skip the header if not wanted
                 packet = packet[4:]
 
         # Listen again if necessary and return the result packet.

--- a/adafruit_rfm69.py
+++ b/adafruit_rfm69.py
@@ -779,11 +779,11 @@ class RFM69:
             else:
                 packet = bytearray(fifo_length)
                 device.readinto(packet)
-            if (rx_filter != _RH_BROADCAST_ADDRESS and packet[0] != _RH_BROADCAST_ADDRESS
-                    and packet[0] != rx_filter):
-                packet = None
-            elif not with_header:  # skip the header if not wanted
-                packet = packet[4:]
+                if (rx_filter != _RH_BROADCAST_ADDRESS and packet[0] != _RH_BROADCAST_ADDRESS
+                        and packet[0] != rx_filter):
+                    packet = None
+                elif not with_header:  # skip the header if not wanted
+                    packet = packet[4:]
 
         # Listen again if necessary and return the result packet.
         if keep_listening:


### PR DESCRIPTION
Corrects an error if packet header receipt is enabled but packet is not addressed to recipient and filtering is enabled. 