### PR TITLE
Example - show packet is received using the LED

### DIFF
--- a/examples/rfm69_simpletest.py
+++ b/examples/rfm69_simpletest.py
@@ -21,6 +21,10 @@ RESET = digitalio.DigitalInOut(board.D6)
 #CS = digitalio.DigitalInOut(board.RFM69_CS)
 #RESET = digitalio.DigitalInOut(board.RFM69_RST)
 
+# Define the onboard LED
+LED = digitalio.DigitalInOut(board.D13)
+LED.direction = digitalio.Direction.OUTPUT
+
 # Initialize SPI bus.
 spi = busio.SPI(board.SCK, MOSI=board.MOSI, MISO=board.MISO)
 
@@ -55,9 +59,12 @@ while True:
     #packet = rfm69.receive(timeout=5.0)
     # If no packet was received during the timeout then None is returned.
     if packet is None:
+        # Packet has not been received
+        LED.value = False
         print('Received nothing! Listening again...')
     else:
         # Received a packet!
+        LED.value = True
         # Print out the raw bytes of the packet:
         print('Received (raw bytes): {0}'.format(packet))
         # And decode to ASCII text and print it too.  Note that you always


### PR DESCRIPTION
Use the onboard LED (or any LED on pin `D13`) to indicate whether a packet was received or not.