### PR TITLE
save last_rssi reading after packet received

### DIFF
--- a/adafruit_rfm69.py
+++ b/adafruit_rfm69.py
@@ -345,6 +345,8 @@ class RFM69:
         self.encryption_key = encryption_key
         # Set transmit power to 13 dBm, a safe value any module supports.
         self.tx_power = 13
+        # last RSSI reading
+        self.last_rssi = 0.
 
     # pylint: disable=no-member
     # Reconsider this disable when it can be tested.
@@ -765,6 +767,8 @@ class RFM69:
                     timed_out = True
         # Payload ready is set, a packet is in the FIFO.
         packet = None
+        # save RSSI
+        self.last_rssi = self.rssi
         # Enter idle mode to stop receiving other packets.
         self.idle()
         if timed_out:

--- a/examples/rfm69_rpi_interrupt.py
+++ b/examples/rfm69_rpi_interrupt.py
@@ -23,7 +23,7 @@ def rfm69_callback(rfm69_irq):
             # Print out the raw bytes of the packet:
             print('Received (raw bytes): {0}'.format(packet))
             print([hex(x) for x in packet])
-            print('RSSI: {0}'.format(rfm69.rssi))
+            print('RSSI: {0}'.format(rfm69.last_rssi))
 
 
 # Define radio parameters.


### PR DESCRIPTION
fixes #22 
the rssi property reads the current state of RSSI register and it may not be meaningful if not read immediately after the packet it received. This PR adds a  last_rssi attribute which holds the RSSI reading from the last packet received.
 

Tested on Raspberry Pi with RFM69 Bonnet