### PR TITLE
Remove the "RuntimeError: Timeout during packet send" error generated…

### DIFF
--- a/adafruit_rfm69.py
+++ b/adafruit_rfm69.py
@@ -687,6 +687,8 @@ class RFM69:
            The timeout is just to prevent a hang (arbitrarily set to 2 seconds)
            The keep_listening argument should be set to True if you want to start listening
            automatically after the packet is sent. The default setting is False.
+
+           Returns: True if success or False if the send timed out.
         """
         # Disable pylint warning to not use length as a check for zero.
         # This is a puzzling warning as the below code is clearly the most

--- a/adafruit_rfm69.py
+++ b/adafruit_rfm69.py
@@ -728,6 +728,8 @@ class RFM69:
         # Enter idle mode to stop receiving other packets.
             self.idle()
 
+        return not timed_out
+
     def receive(self, timeout=0.5, keep_listening=True, with_header=False,
                 rx_filter=_RH_BROADCAST_ADDRESS):
         """Wait to receive a packet from the receiver. Will wait for up to timeout_s amount of

--- a/adafruit_rfm69.py
+++ b/adafruit_rfm69.py
@@ -727,8 +727,6 @@ class RFM69:
         else:
         # Enter idle mode to stop receiving other packets.
             self.idle()
-        if timed_out:
-            raise RuntimeError('Timeout during packet send')
 
     def receive(self, timeout=0.5, keep_listening=True, with_header=False,
                 rx_filter=_RH_BROADCAST_ADDRESS):


### PR DESCRIPTION
Remove the error generated when a packet send times out. Fixes issue #26.