### PR TITLE
Added timeout which raises an exception to avoid an infinite loop

### DIFF
--- a/adafruit_rfm69.py
+++ b/adafruit_rfm69.py
@@ -475,7 +475,8 @@ class RFM69:
         self._write_u8(_REG_OP_MODE, op_mode)
         # Wait for mode to change by polling interrupt bit.
         while not self.mode_ready:
-            pass
+            if (time.monotonic() - start) >= 1:
+                raise RuntimeError('Operation mode failed to set.')
 
     @property
     def sync_word(self):

--- a/adafruit_rfm69.py
+++ b/adafruit_rfm69.py
@@ -477,7 +477,7 @@ class RFM69:
         start = time.monotonic()
         while not self.mode_ready:
             if (time.monotonic() - start) >= 1:
-                raise RuntimeError('Operation mode failed to set.')
+                raise RuntimeError("Operation mode failed to set.")
 
     @property
     def sync_word(self):

--- a/adafruit_rfm69.py
+++ b/adafruit_rfm69.py
@@ -474,6 +474,7 @@ class RFM69:
         op_mode |= val << 2
         self._write_u8(_REG_OP_MODE, op_mode)
         # Wait for mode to change by polling interrupt bit.
+        start = time.monotonic()
         while not self.mode_ready:
             if (time.monotonic() - start) >= 1:
                 raise RuntimeError('Operation mode failed to set.')

--- a/adafruit_rfm69.py
+++ b/adafruit_rfm69.py
@@ -477,7 +477,7 @@ class RFM69:
         start = time.monotonic()
         while not self.mode_ready:
             if (time.monotonic() - start) >= 1:
-                raise RuntimeError("Operation mode failed to set.")
+                raise TimeoutError("Operation Mode failed to set.")
 
     @property
     def sync_word(self):


### PR DESCRIPTION
While instantiating an RFM69 I found that the RFM driver was hanging because `self.mode_ready` was never True. Added a 1 second timeout that raises an exception. We should discuss the exception type, error message and timeout duration.