### PR TITLE
Fix setting of the Power amplifiers when power boost is enabled

### DIFF
--- a/adafruit_rfm69.py
+++ b/adafruit_rfm69.py
@@ -661,10 +661,10 @@ class RFM69:
         if not pa0 and pa1 and not pa2:
             # -2 to 13 dBm range
             return -18 + current_output_power
-        if not pa0 and pa1 and pa2 and self.high_power and self.tx_power < 18:
+        if not pa0 and pa1 and pa2 and self.high_power and self._tx_power < 18:
             # 2 to 17 dBm range
             return -14 + current_output_power
-        if not pa0 and pa1 and pa2 and self.high_power and self.tx_power >= 18:
+        if not pa0 and pa1 and pa2 and self.high_power and self._tx_power >= 18:
             # 5 to 20 dBm range
             return -11 + current_output_power
         raise RuntimeError("Power amps state unknown!")

--- a/adafruit_rfm69.py
+++ b/adafruit_rfm69.py
@@ -661,10 +661,10 @@ class RFM69:
         if not pa0 and pa1 and not pa2:
             # -2 to 13 dBm range
             return -18 + current_output_power
-        if not pa0 and pa1 and pa2 and not self.high_power:
+        if not pa0 and pa1 and pa2 and self.high_power and self.tx_power < 18:
             # 2 to 17 dBm range
             return -14 + current_output_power
-        if not pa0 and pa1 and pa2 and self.high_power:
+        if not pa0 and pa1 and pa2 and self.high_power and self.tx_power >= 18:
             # 5 to 20 dBm range
             return -11 + current_output_power
         raise RuntimeError("Power amps state unknown!")

--- a/adafruit_rfm69.py
+++ b/adafruit_rfm69.py
@@ -320,9 +320,6 @@ class RFM69:
         self._write_u8(_REG_FIFO_THRESH, 0b10001111)
         # Configure low beta off.
         self._write_u8(_REG_TEST_DAGC, 0x30)
-        # Disable boost.
-        self._write_u8(_REG_TEST_PA1, _TEST_PA1_NORMAL)
-        self._write_u8(_REG_TEST_PA2, _TEST_PA2_NORMAL)
         # Set the syncronization word.
         self.sync_word = sync_word
         self.preamble_length = preamble_length  # Set the preamble length.


### PR DESCRIPTION
fixes #47 

Fixes previous error in setting power amplifiers.
Also fixes reporting of tx_power for levels 14-17
Turns off Overload Current protection when tx_power is >18 as specified int he Data sheet.

Tested on feather_m0_rfm69 and Raspberry Pi bonnet.

Additional testing welcome.

This does add about 50 bytes of code to the EN build for the feather_m0_rfm69 but it still fits....